### PR TITLE
Conditionally Load Front End Assets

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -166,6 +166,11 @@
         "area": "markdowneditor.area.general"
       },
       {
+        "key": "general.load_front_end",
+        "value": false,
+        "area": "markdowneditor.area.general"
+      },
+      {
         "key": "general.include_highlight",
         "value": true,
         "type": "combo-boolean",

--- a/core/components/markdowneditor/model/markdowneditor/Event/OnWebPageInit.php
+++ b/core/components/markdowneditor/model/markdowneditor/Event/OnWebPageInit.php
@@ -5,7 +5,7 @@ class OnWebPageInit extends Event {
 
     public function init()
     {
-        return true;
+        return (bool)$this->md->getOption('general.load_front_end', null, false);
     }
 
     public function process() {


### PR DESCRIPTION
Markdown Editor should not load its assets on the front end for no reason. This adds a setting that defaults to false to prevent it from doing so by default.

Closes theboxer/markdown-editor#11