### PR TITLE
Prevent MarkdownEditor from loading for elements

### DIFF
--- a/core/components/markdowneditor/elements/plugins/markdowneditor.plugin.php
+++ b/core/components/markdowneditor/elements/plugins/markdowneditor.plugin.php
@@ -6,6 +6,23 @@
  *
  *
  */
+
+// Check scenarios where MarkdownEditor should not be loaded
+$elementEditor = $modx->getOption('which_element_editor');
+$resourceEditor = $modx->getOption('which_editor');
+if ($modx->event->name === 'OnRichTextEditorInit' && !$modx->resource) {
+	// If the element editor is not MarkdownEditor, return without loading
+	if ($elementEditor !== 'MarkdownEditor') {
+		return;
+	}
+}
+else if ($modx->resource) {
+	// If MarkdownEditor is not selected, return
+	if ($resourceEditor !== 'MarkdownEditor') {
+		return;
+	}
+}
+
 $corePath = $modx->getOption('markdowneditor.core_path', null, $modx->getOption('core_path', null, MODX_CORE_PATH) . 'components/markdowneditor/');
 /** @var MarkdownEditor $markdowneditor */
 $markdowneditor = $modx->getService(


### PR DESCRIPTION
Added a check ahead of loading MarkdownEditor so that it doesn't conflict with Ace editor for Elements.